### PR TITLE
Permit passing build variables to the container

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,22 @@
 # Instructions
 
+Build docker container with which to build GrapheneOS:
 ```
 docker build -t gos-reproducibility .
 ```
 
+Environment variables for entrypoint build script:
+`DEVICE` - defaults to bluejay
+`BUILD_ID` - defaults to "TQ2A.230505.002"
+`OFFICIAL_BUILD` - defaults to true
+`BUILD_DATETIME` - defaults to 1686159583
+`BUILD_NUMBER` - defaults to 2023060700
+
+
+Build GrapheneOS for a specific device using the `grapheneos-tree` directory in the current working directory to
+store repository and build information, removing the ephemeral container when done:
 ```
-docker run --privileged -v "./grapheneos-tree/:/opt/build/grapheneos/" gos-reproducibility
+docker run --rm --privileged -e "DEVICE=raven" -v "./grapheneos-tree/:/opt/build/grapheneos/" gos-reproducibility
 ```
+Note: permitting TTY use results in git complaining about the user configuration inside the container,
+do not pass `-t` (for now).

--- a/entrypoint.bash
+++ b/entrypoint.bash
@@ -4,16 +4,16 @@ set -o errexit -o pipefail
 
 sudo chown builduser:builduser /opt/build/
 
-export DEVICE=bluejay
-export BUILD_ID=TQ2A.230505.002
-export OFFICIAL_BUILD=true
-export BUILD_DATETIME=1686159583
-export BUILD_NUMBER=2023060700
+export DEVICE=${DEVICE:=bluejay}
+export BUILD_ID=${BUILD_ID:="TQ2A.230505.002"}
+export OFFICIAL_BUILD=${OFFICIAL_BUILD:=true}
+export BUILD_DATETIME=${BUILD_DATETIME:=1686159583}
+export BUILD_NUMBER=${BUILD_NUMBER:=2023060700}
 
 echo "[INFO] Downloading and verifying manifest"
 mkdir -p /opt/build/grapheneos
 cd /opt/build/grapheneos
-repo init -u https://github.com/GrapheneOS/platform_manifest.git -b refs/tags/TQ2A.230505.002.2023060700
+repo init -u https://github.com/GrapheneOS/platform_manifest.git -b refs/tags/${BUILD_ID}.${BUILD_NUMBER}
 mkdir ~/.ssh && curl https://grapheneos.org/allowed_signers > ~/.ssh/grapheneos_allowed_signers
 cd .repo/manifests
 git config gpg.ssh.allowedSignersFile ~/.ssh/grapheneos_allowed_signers
@@ -21,7 +21,7 @@ git verify-tag $(git describe)
 cd ../..
 
 echo "[INFO] Syncing GrapheneOS tree"
-repo sync -j16
+repo sync -j$(nproc)
 
 echo "[INFO] Setting up adevtool"
 yarn install --cwd vendor/adevtool/


### PR DESCRIPTION
Modify the entrypoint (and README) to use currently hardcoded vars for default values, while permitting the user to pass env vars to the container to build various releases, target devices, etc.